### PR TITLE
Resolve issues with x64 Branch & Add user expected behaviour

### DIFF
--- a/cpp/CMakeSettings.json
+++ b/cpp/CMakeSettings.json
@@ -42,8 +42,7 @@
       "cmakeCommandArgs": "",
       "buildCommandArgs": "",
       "ctestCommandArgs": "",
-      "inheritEnvironments": [ "msvc_x86" ],
-      "variables": []
+      "inheritEnvironments": [ "msvc_x86" ]
     }
   ]
 }

--- a/cpp/GRPCTest.cpp
+++ b/cpp/GRPCTest.cpp
@@ -5,6 +5,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <utility>
+#include <vector>
+
+#define DISCORD_RPC_VERSION 1, 2, 1
 
 DiscordUser cbConUser;
 std::pair<int, char> cbDisconnected;
@@ -211,6 +214,14 @@ LUA_FUNCTION(UpdateDiscordStatus) {
 }
 
 GMOD_MODULE_OPEN() {
+    // Set the current version as a vector
+    std::vector<int> version = {DISCORD_RPC_VERSION};
+
+    Vector semver;
+    semver.x = version[0];
+    semver.y = version[1];
+    semver.z = version[2];
+
     // Create the functions
     LUA->PushSpecial(GarrysMod::Lua::SPECIAL_GLOB);
     LUA->PushCFunction(StartDiscordStatus);
@@ -230,6 +241,11 @@ GMOD_MODULE_OPEN() {
     LUA->PushSpecial(GarrysMod::Lua::SPECIAL_GLOB);
     LUA->PushCFunction(UpdateDiscordStatus);
     LUA->SetField(-2, "DiscordUpdateRPC");
+    LUA->Pop();
+
+    LUA->PushSpecial(GarrysMod::Lua::SPECIAL_GLOB);
+    LUA->PushVector(semver);
+    LUA->SetField(-2, "DiscordRPCVersion");
     LUA->Pop();
 
     return 0;

--- a/cpp/GRPCTest.cpp
+++ b/cpp/GRPCTest.cpp
@@ -7,7 +7,7 @@
 #include <utility>
 #include <vector>
 
-#define DISCORD_RPC_VERSION 1, 2, 1
+#define DISCORD_RPC_VERSION 121
 
 DiscordUser cbConUser;
 std::pair<int, char> cbDisconnected;
@@ -214,14 +214,6 @@ LUA_FUNCTION(UpdateDiscordStatus) {
 }
 
 GMOD_MODULE_OPEN() {
-    // Set the current version as a vector
-    std::vector<int> version = {DISCORD_RPC_VERSION};
-
-    Vector semver;
-    semver.x = version[0];
-    semver.y = version[1];
-    semver.z = version[2];
-
     // Create the functions
     LUA->PushSpecial(GarrysMod::Lua::SPECIAL_GLOB);
     LUA->PushCFunction(StartDiscordStatus);
@@ -243,8 +235,9 @@ GMOD_MODULE_OPEN() {
     LUA->SetField(-2, "DiscordUpdateRPC");
     LUA->Pop();
 
+    // Set the current version of the module
     LUA->PushSpecial(GarrysMod::Lua::SPECIAL_GLOB);
-    LUA->PushVector(semver);
+    LUA->PushNumber(DISCORD_RPC_VERSION);
     LUA->SetField(-2, "DiscordRPCVersion");
     LUA->Pop();
 

--- a/cpp/GRPCTest.cpp
+++ b/cpp/GRPCTest.cpp
@@ -2,6 +2,7 @@
 #include "GarrysMod/Lua/Interface.h"
 #include "discord_rpc.h"
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <utility>
 
@@ -175,33 +176,34 @@ LUA_FUNCTION(UpdateDiscordStatus) {
     LUA->GetField(1, "instance");
     discordP.instance = LUA->GetNumber();
 
-    LUA->GetField(1, "buttonPrimaryLabel");
-    if (LUA->GetType(-1) == GarrysMod::Lua::Type::String) {
-        DiscordRichPresenceButton button;
+    int buttonI = 0;
 
-        button.label = LUA->GetString();
+    LUA->GetField(1, "buttonPrimaryLabel");
+    if (LUA->GetString() != NULL) {
+        discordP.buttons[buttonI] = (DiscordRichPresenceButton *)malloc(
+            sizeof(DiscordRichPresenceButton));
+
+        discordP.buttons[buttonI]->label = LUA->GetString();
 
         LUA->GetField(1, "buttonPrimaryUrl");
         LUA->CheckString();
 
-        button.url = LUA->GetString();
+        discordP.buttons[buttonI]->url = LUA->GetString();
 
-        discordP.buttons[0] = &button;
+        buttonI += 1;
     }
 
     LUA->GetField(1, "buttonSecondaryLabel");
-    if (LUA->GetType(-1) == GarrysMod::Lua::Type::String) {
-        DiscordRichPresenceButton button;
+    if (LUA->GetString() != NULL) {
+        discordP.buttons[buttonI] = (DiscordRichPresenceButton *)malloc(
+            sizeof(DiscordRichPresenceButton));
 
-        button.label = LUA->GetString();
+        discordP.buttons[buttonI]->label = LUA->GetString();
 
         LUA->GetField(1, "buttonSecondaryUrl");
         LUA->CheckString();
 
-        button.url = LUA->GetString();
-
-#pragma warning(disable : 6201)
-        discordP.buttons[1] = &button;
+        discordP.buttons[buttonI]->url = LUA->GetString();
     }
 
     Discord_UpdatePresence(&discordP);

--- a/cpp/GRPCTest.cpp
+++ b/cpp/GRPCTest.cpp
@@ -5,7 +5,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <utility>
-#include <vector>
 
 #define DISCORD_RPC_VERSION 121
 


### PR DESCRIPTION
This PR is kind of a continuation of #16. Once I tested the built binaries with x64 branch, it didn't seem to work and once I debugged it, it appeared that the buttons were never allocated in memory thus resulting in faulty RPC Data sent to Discord Client. 

So this PR adds these three following:
- Interpret the given `buttonPrimaryLabel` as string properly by using `LUA->GetString() != NULL` au lieu of type-checking. Consequently the given thing is interpreted according to user's intention
- Set buttons dynamically: in case primary isn't supplied and only secondary is present, solely display the second one (instead of crashing)
- Slightly change the implementation method for buttons

- Add semver as a vector so users can check the library version by `DiscordRPCVersion == Vector(1, 2, 1)` (in this PR the version is declared as 1.2.1)